### PR TITLE
Change X-Frame-Option header, fixes #73

### DIFF
--- a/src/goalkeeper/settings.py
+++ b/src/goalkeeper/settings.py
@@ -142,3 +142,5 @@ THUMBNAIL_PROCESSORS = (
     'easy_thumbnails.processors.autocrop',
     'filer.thumbnail_processors.scale_and_crop_with_subject_location',
     'easy_thumbnails.processors.filters', )
+
+X_FRAME_OPTIONS = 'SAMEORIGIN'


### PR DESCRIPTION
* Summernote editor is included as iframe and
  requires X-Frame-Options SAMEORIGIN header.