### PR TITLE
Change default position of images in news from left to center, fixes #61

### DIFF
--- a/src/gui/static/style.css
+++ b/src/gui/static/style.css
@@ -98,8 +98,9 @@ hr {
   font-weight: bold;
 }
 
-.news-text {
-
+.news img {
+  margin-left: 50%;
+  transform: translateX(-50%);
 }
 
 .news-date {

--- a/src/gui/templates/news.html
+++ b/src/gui/templates/news.html
@@ -5,7 +5,7 @@
       <h2>Neuigkeiten</h2>
 {% if news_list %}
   {% for news_item in news_list %}
-      <div class="content-item editable-content">
+      <div class="news content-item editable-content">
         <p class="news-title">{{ news_item.title }}</p>
         <hr noshade>
         <p>{{ news_item.text }}</p>


### PR DESCRIPTION
Change default position of images in news from left to center, fixes #61

Please check, if
- issue was understood correctly
- if css is compiled and actually works fine 