### PR TITLE
Rename Stundensatz to Vergütung, fixes #109

### DIFF
--- a/src/gui/admin.py
+++ b/src/gui/admin.py
@@ -30,7 +30,7 @@ def timesheet_to_csv(queryset, writer):
     """
     Convert timesheet data to CSV
     """
-    writer.writerow(["Kursleiter*in", "Kurs", "Datum", "Stunden", "Stundensatz"])
+    writer.writerow(["Kursleiter*in", "Kurs", "Datum", "Stunden", "Vergütung"])
     for row in queryset:
         writer.writerow([row.instructor, row.course, row.date, row.hours, row.rate])
 

--- a/src/gui/migrations/0023_auto_20220727_1351.py
+++ b/src/gui/migrations/0023_auto_20220727_1351.py
@@ -17,11 +17,11 @@ class Migration(migrations.Migration):
             name='HourlyRate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('rate', models.IntegerField(verbose_name='Stundensatz')),
+                ('rate', models.IntegerField(verbose_name='Vergütung')),
             ],
             options={
-                'verbose_name': 'Stundensatz',
-                'verbose_name_plural': 'Stundensätze',
+                'verbose_name': 'Vergütung',
+                'verbose_name_plural': 'Vergütungen',
             },
         ),
         migrations.AddField(

--- a/src/gui/models/timesheet.py
+++ b/src/gui/models/timesheet.py
@@ -12,11 +12,11 @@ class HourlyRate(models.Model):
     """
     The hourly rates that are possible
     """
-    rate = models.IntegerField('Stundensatz', blank=False)
+    rate = models.IntegerField('Vergütung', blank=False)
 
     class Meta:
-        verbose_name = 'Stundensatz'
-        verbose_name_plural = 'Stundensätze'
+        verbose_name = 'Vergütung'
+        verbose_name_plural = 'Vergütungen'
 
     def __str__(self):
         return str(self.rate)
@@ -35,7 +35,7 @@ class TimeSheet(models.Model):
     date = models.DateField('Tag')
     rate = models.ForeignKey(HourlyRate,
                              on_delete=models.CASCADE,
-                             verbose_name="Stundensatz")
+                             verbose_name="Vergütung")
 
     class Meta:
         verbose_name = 'Stundenerfassung'


### PR DESCRIPTION
This PR renames "Stundensatz" to "Vergütung". To get there I did the following:
- rename it in the model
- rename it in the GUI
- rename it in the migration

Could you please check if it works like this and if we'll be running into an issue because I changed a migration file, that has been already deployed. 

Fixes #109 
