### PR TITLE
Rename "Meine Kurse" to "Meine Übungen", fixes #115 

### DIFF
--- a/src/gui/templates/courses.html
+++ b/src/gui/templates/courses.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-      <h2>Meine Kurse</h2>
+      <h2>Meine Übungen</h2>
 {% if course_list %}
   {% for course in course_list %}
     <a href="/gui/course/{{ course.id }}" class="div-link">

--- a/src/gui/templates/menu.html
+++ b/src/gui/templates/menu.html
@@ -43,7 +43,7 @@
             <li><a href="/gui/logout">Abmelden</a></li>
 {% else %}
             <li><a href="/gui/news">Neuigkeiten</a></li>
-            <li><a href="/gui/courses">Meine Kurse</a></li>
+            <li><a href="/gui/courses">Meine Übungen</a></li>
             <li><a href="{{ request.documentation_alt_url }}">Wissen & Dokumente</a></li>
             <li><a href="/gui/contact">Kontakt</a></li>
             <li><a href="/gui/timesheet">Stundenerfassung</a></li>


### PR DESCRIPTION
Rename "Meine Kurse" to "Meine Übungen" both in the menu and in the page overview

Fixes #115 