### PR TITLE
Remove warning for required fields, fixes #117

### DIFF
--- a/src/gui/templates/course.html
+++ b/src/gui/templates/course.html
@@ -23,8 +23,5 @@
         </div>
       </a>
     {% endfor %}
-    <div class="content-item" style="background: #fff;">
-      <img class="icon-inline" src="{% static "heroicons/icon-exclamation.svg" %}"> Diese Einheiten sind verpflichtend.
-    </div>
   {% endif %}
 {% endblock %}

--- a/src/gui/templates/lesson.html
+++ b/src/gui/templates/lesson.html
@@ -47,9 +47,6 @@
      </div>
     </a>
   {% endfor %}
-    <div class="content-item" style="background: #fff;">
-      <img style="height: 1em;" src="{% static "heroicons/icon-exclamation.svg" %}"> Diese Einheiten sind verpflichtend.
-    </div>
     <div class="content-item bg-white"></div>
 {% endif %}
 {% if lesson_details.questions %}


### PR DESCRIPTION
This PR removes the warning for required fields in the following files:

- course
- lesson

Maybe this would also include to remove the mandatory checkbox in the lesson model, but I wasn't entirely sure if those are not two separate things so I left it out for the moment 

Fixes #117 