### PR TITLE
Rename subsection in lesson overview, fixes #118

### DIFF
--- a/src/gui/templates/lesson.html
+++ b/src/gui/templates/lesson.html
@@ -32,7 +32,7 @@
       </div>
 {% endif %}
 {% if sub_lesson_list %}
-    <h3 class="centered">Untergeordnete Lerneinheiten</h3>
+    <h3 class="centered">Unterthemen</h3>
   {% for lesson in sub_lesson_list %}
     <a href="/gui/course/{{ course.id }}/{{ lesson.id }}/" class="div-link">
       <div class="content-item centered {% if lesson.needs_feedback == 1 %}bg-ish{% else %}bg-grey{% endif %}">


### PR DESCRIPTION
Rename "Untergeordnete Lerneinheiten" to "Unterthemen"

Fixes #118 